### PR TITLE
Allow boolean for directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To install, add the following to your project `:dependencies`:
 (def policy {:default-src :none
              :script-src [:self :nonce]
              :style-src ["https://example.com" :unsafe-inline]
+             :block-all-mixed-content true
              :report-uri "/csp-report"})
 
 (def app
@@ -48,8 +49,9 @@ You can use `compose` function.
 ```clojure
 (ring-middleware-csp.core/compose {:default-src :none
                                    :style-src ["https://example.com" :unsafe-inline]
+                                   :block-all-mixed-content true
                                    :report-uri "/csp-report"})
-=> "default-src 'none';style-src https://example.com 'unsafe-inline';report-uri /csp-report"
+=> "default-src 'none';style-src https://example.com 'unsafe-inline';block-all-mixed-content;report-uri /csp-report"
 
 ; with nonce
 (ring-middleware-csp.core/compose {:default-src :none

--- a/src/ring_middleware_csp/core.clj
+++ b/src/ring_middleware_csp/core.clj
@@ -27,7 +27,7 @@
   [nonce [d v]]
   (case v
     true (name d)
-    false nil
+    (false nil) nil
     (str (name d) " " (value->str v nonce))))
 
 (defn compose

--- a/src/ring_middleware_csp/core.clj
+++ b/src/ring_middleware_csp/core.clj
@@ -57,7 +57,9 @@
                                    :else
                                    %)
                                 values)]
-                [(keyword name) values])))
+                [(keyword name) (if (seq values)
+                                  values
+                                  true)])))
        (into {})))
 
 (def ^:private make-template

--- a/src/ring_middleware_csp/core.clj
+++ b/src/ring_middleware_csp/core.clj
@@ -23,13 +23,22 @@
                :else %))
        (str/join " ")))
 
+(defn- ->directive
+  [nonce [d v]]
+  (case v
+    true (name d)
+    false nil
+    (str (name d) " " (value->str v nonce))))
+
 (defn compose
   "Make string value for CSP header from policy map"
   ([policy]
    (compose policy nil))
   ([policy nonce]
-   (->> policy
-        (map (fn [[d v]] (str (name d) " " (value->str v nonce))))
+   (->> (for [entry policy
+              :let [directive-str (->directive nonce entry)]
+              :when (seq directive-str)]
+          directive-str)
         (str/join ";"))))
 
 (defn parse

--- a/test/ring_middleware_csp/core_test.clj
+++ b/test/ring_middleware_csp/core_test.clj
@@ -24,6 +24,10 @@
     (is (= "default-src 'self';script-src 'self'"
            (compose {:default-src [:self]
                      :block-all-mixed-content false
+                     :script-src [:self]})))
+    (is (= "default-src 'self';script-src 'self'"
+           (compose {:default-src [:self]
+                     :block-all-mixed-content nil
                      :script-src [:self]}))))
   (testing "with nonce"
     (is (= "script-src 'self' 'nonce-abcdefg'"

--- a/test/ring_middleware_csp/core_test.clj
+++ b/test/ring_middleware_csp/core_test.clj
@@ -16,7 +16,15 @@
     (is (= "script-src 'self';report-uri /csp-report-path;report-to csp-endpoint"
            (compose {:script-src [:self]
                      :report-uri "/csp-report-path"
-                     :report-to "csp-endpoint"}))))
+                     :report-to "csp-endpoint"})))
+    (is (= "default-src 'self';block-all-mixed-content;script-src 'self'"
+           (compose {:default-src [:self]
+                     :block-all-mixed-content true
+                     :script-src [:self]})))
+    (is (= "default-src 'self';script-src 'self'"
+           (compose {:default-src [:self]
+                     :block-all-mixed-content false
+                     :script-src [:self]}))))
   (testing "with nonce"
     (is (= "script-src 'self' 'nonce-abcdefg'"
            (compose {:script-src [:self :nonce]} "abcdefg")))
@@ -37,7 +45,11 @@
     (is (= {:script-src [:self]
             :report-uri ["/csp-report-path"]
             :report-to ["csp-endpoint"]}
-           (parse "script-src 'self';report-uri /csp-report-path;report-to csp-endpoint"))))
+           (parse "script-src 'self';report-uri /csp-report-path;report-to csp-endpoint")))
+    (is (= {:default-src [:self]
+            :block-all-mixed-content true
+            :script-src [:self]}
+           (parse "default-src 'self';block-all-mixed-content;script-src 'self'"))))
   (testing "with nonce"
     (is (= {:script-src [:self :nonce]}
            (parse "script-src 'self' 'nonce-abcdefg'")))

--- a/test/ring_middleware_csp/core_test.clj
+++ b/test/ring_middleware_csp/core_test.clj
@@ -16,26 +16,29 @@
     (is (= "script-src 'self';report-uri /csp-report-path;report-to csp-endpoint"
            (compose {:script-src [:self]
                      :report-uri "/csp-report-path"
-                     :report-to "csp-endpoint"})))
-    (is (= "default-src 'self';block-all-mixed-content;script-src 'self'"
-           (compose {:default-src [:self]
-                     :block-all-mixed-content true
-                     :script-src [:self]})))
-    (is (= "default-src 'self';script-src 'self'"
-           (compose {:default-src [:self]
-                     :block-all-mixed-content false
-                     :script-src [:self]})))
-    (is (= "default-src 'self';script-src 'self'"
-           (compose {:default-src [:self]
-                     :block-all-mixed-content nil
-                     :script-src [:self]}))))
+                     :report-to "csp-endpoint"}))))
   (testing "with nonce"
     (is (= "script-src 'self' 'nonce-abcdefg'"
            (compose {:script-src [:self :nonce]} "abcdefg")))
     (is (= "script-src 'self' 'nonce-abcdefg';style-src 'nonce-abcdefg'"
            (compose {:script-src [:self :nonce]
                      :style-src :nonce}
-                    "abcdefg")))))
+                    "abcdefg"))))
+  (testing "boolean"
+    (testing "true"
+      (is (= "default-src 'self';block-all-mixed-content;script-src 'self'"
+             (compose {:default-src [:self]
+                       :block-all-mixed-content true
+                       :script-src [:self]}))))
+    (testing "falsy"
+      (is (= "default-src 'self';script-src 'self'"
+             (compose {:default-src [:self]
+                       :block-all-mixed-content false
+                       :script-src [:self]})))
+      (is (= "default-src 'self';script-src 'self'"
+             (compose {:default-src [:self]
+                       :block-all-mixed-content nil
+                       :script-src [:self]}))))))
 
 (deftest parse-test
   (testing "without nonce"


### PR DESCRIPTION
Some directives like `block-all-mixed-content` work without any values:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content

```
Content-Security-Policy: block-all-mixed-content;
```

I believe that `{:block-all-mixed-content true}` looks more idiomatic than  `{:block-all-mixed-content ""}`.