### PR TITLE
fix whitespace bug

### DIFF
--- a/src/ring_middleware_csp/core.clj
+++ b/src/ring_middleware_csp/core.clj
@@ -37,7 +37,7 @@
   [policy-str]
   (->> (str/split policy-str #";")
        (map (fn [v]
-              (let [[name & values] (str/split v #" +")
+              (let [[name & values] (str/split (str/trim v) #" +")
                     values (map #(cond
                                    (str/starts-with? % "'nonce-")
                                    :nonce

--- a/test/ring_middleware_csp/core_test.clj
+++ b/test/ring_middleware_csp/core_test.clj
@@ -43,7 +43,12 @@
            (parse "script-src 'self' 'nonce-abcdefg'")))
     (is (= {:script-src [:self :nonce]
             :style-src [:nonce]}
-           (parse "script-src 'self' 'nonce-abcdefg';style-src 'nonce-abcdefg'")))))
+           (parse "script-src 'self' 'nonce-abcdefg';style-src 'nonce-abcdefg'"))))
+  (testing "whitespaces"
+    (is (= {:script-src [:self]
+            :style-src [:self]}
+           (parse "script-src 'self'; style-src 'self'"))
+        "add whitespace after ';'")))
 
 (deftest wrap-csp-test
   (let [handler (constantly {:status 200 :headers {} :body ""})]


### PR DESCRIPTION
bug:
```clojure
(parse "script-src 'self'; style-src 'self'")
=> {:script-src (:self), : ("style-src" :self)}
```

Adding whitespaces after ';' is valid.

working examples with whitespaces after a semicolon.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

specification
https://w3c.github.io/webappsec-csp/#framework-policy