### PR TITLE
Configure SecureRandom algorithm for MS-Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ If you set to `true`, enable to generate nonce.
 
 ### `:nonce-generator`
 By using `:nonce-generator`, you can use custom nonce generator.
-Default generator use [`SecureRandom`](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html) (using "NativePRNGNonBlocking" algorithm) and
+Default generator use [`SecureRandom`](https://docs.oracle.com/javase/8/docs/api/java/security/SecureRandom.html) (using "NativePRNGNonBlocking" algorithm
+or, on MS-Windows, the [default implementation](https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SecureRandomImp)) and
 [`java.util.Base64`](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html).
 It generates base64 string from 256bit random data.
 

--- a/src/ring_middleware_csp/core.clj
+++ b/src/ring_middleware_csp/core.clj
@@ -8,7 +8,9 @@
     Base64)))
 
 (defn- make-nonce-generator []
-  (let [sr (SecureRandom/getInstance "NativePRNGNonBlocking")
+  (let [sr (if (.startsWith (System/getProperty "os.name") "Windows")
+             (SecureRandom.)
+             (SecureRandom/getInstance "NativePRNGNonBlocking"))
         be (Base64/getEncoder)]
     (fn []
       (let [ba (byte-array 32)]


### PR DESCRIPTION
Hi,

could you please consider a fix for #4. 

It leaves it to `SecureRandom` to choose an appropriate algorithm to use for MS-Windows. 

It appears there are [two algorithms](https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SecureRandomImp) available on Windows,  `SHA1PRNG` and `Windows-PRNG`. It will default to the first. 

Thanks